### PR TITLE
docs(auth): readme auth operator guide + phase exit [P5.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,27 @@ pnpm test:unit
 # E2E tests
 pnpm test
 ```
+
+### Auth (GitHub + Supabase)
+
+Sign-in uses Supabase Auth with GitHub OAuth. New users get a `public.profiles` row automatically via the `on_auth_user_created` trigger (see `supabase/migrations/*_on_auth_user_created.sql`).
+
+| Environment | GitHub OAuth app | Supabase GitHub callback (set in GitHub app) | App redirect allow-list |
+| --- | --- | --- | --- |
+| **Production** | CodingStats | `https://rzrykoldaspzesdlfkgy.supabase.co/auth/v1/callback` | `https://codingstats.vercel.app/login-redirect` (and `https://coding-stats.vercel.app/login-redirect` if that hostname is still in use) |
+| **Local** | CodingStatsDev | `http://localhost:54321/auth/v1/callback` | `http://localhost:5173/login-redirect` |
+
+**Production setup:** Supabase dashboard → Authentication → Providers → GitHub (enabled, CodingStats client ID/secret). Authentication → URL configuration → add the production `login-redirect` URLs above.
+
+**Local setup:** Copy `supabase/config.toml.example` to `supabase/config.toml` (gitignored). Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` from CodingStatsDev, then `supabase start` (or `pnpm dev:fresh` / `pnpm dev:resume`).
+
+**Apply DB migrations to hosted Supabase:** from a linked project, `supabase db push --linked` (after P5.01 migration is merged).
+
+**Existing user without a profile row** (one-off, no backfill script):
+
+```sql
+INSERT INTO public.profiles (id, email, name)
+VALUES ('<your-auth-users-uuid>', '<email>', '<display-name>');
+```
+
+Find `<your-auth-users-uuid>` in Supabase → Authentication → Users.

--- a/docs/product/delivery/phase-05/reviews/P5.03-pr-review.triage.json
+++ b/docs/product/delivery/phase-05/reviews/P5.03-pr-review.triage.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-05-20T05:13:22.073Z",
+  "outcome": "skipped",
+  "note": "PR review disabled by policy",
+  "prBodyRefresh": {
+    "attemptedAt": "2026-05-20T05:13:25.064Z",
+    "status": "updated"
+  }
+}

--- a/docs/product/delivery/phase-05/ticket-03-auth-docs-and-phase-exit.md
+++ b/docs/product/delivery/phase-05/ticket-03-auth-docs-and-phase-exit.md
@@ -43,3 +43,5 @@ Red: skip
 Why this path: smallest operator surface in README; defers a full `docs/` auth guide
 Alternative considered: separate `docs/auth.md` — rejected for 1-point doc ticket
 Deferred: RLS; backfill; hostname cleanup PR
+
+Phase exit (2026-05-20): README auth section and product plan status updated. Hosted `supabase db push --linked` and fresh prod/local GitHub signup smoke checks are **operator-owned** — not run in this delivery session (worktree has no `supabase link`). After merge: push migration, sign in once on prod and local to confirm `profiles` row exists.

--- a/docs/product/plans/phase-05-auth-profile-provisioning.md
+++ b/docs/product/plans/phase-05-auth-profile-provisioning.md
@@ -1,6 +1,6 @@
 # Phase 05: Auth Profile Provisioning
 
-**Delivery status:** Product plan approved. Delivery decomposition: `docs/product/delivery/phase-05/implementation-plan.md`.
+**Delivery status:** Delivered — see stacked PRs for P5.01–P5.03 and `docs/product/delivery/phase-05/implementation-plan.md`.
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P5.03 README auth operator guide + phase exit`
- ticket file: [docs/product/delivery/phase-05/ticket-03-auth-docs-and-phase-exit.md](https://github.com/cesarnml/coding-stats/blob/main/docs/product/delivery/phase-05/ticket-03-auth-docs-and-phase-exit.md)
- stacked base branch: `agents/p5-02-local-supabase-auth-config-template`
- post-verify: outcome `clean` completed at 2026-05-20 05:13 UTC
