### PR TITLE
refactor(charts): standalone charts [P6.04]

### DIFF
--- a/docs/product/delivery/phase-06/reviews/P6.04-pr-review.triage.json
+++ b/docs/product/delivery/phase-06/reviews/P6.04-pr-review.triage.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-06-17T03:39:37.505Z",
+  "outcome": "skipped",
+  "note": "PR review disabled by policy",
+  "prBodyRefresh": {
+    "attemptedAt": "2026-06-17T03:39:40.760Z",
+    "status": "updated"
+  }
+}

--- a/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.ledger.json
+++ b/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.ledger.json
@@ -17,6 +17,21 @@
       "findings": [],
       "probedSurfaces": [],
       "patches": []
+    },
+    {
+      "runnerKind": "operator-recorder",
+      "reviewedHeadSha": "dc35ac26f0932894469f3a05393460306f14e34e",
+      "outcome": "deferred",
+      "completedAt": "2026-06-17T03:38:42.472Z",
+      "terminatedReason": "completed",
+      "findings": [],
+      "probedSurfaces": [],
+      "patches": [],
+      "reason": "Condition B false positive: subagent used --- horizontal rules in report (violating template instructions), causing the section parser to misread the Actionable findings section. Actual findings: None. Advisory observations are non-blocking doc-vs-code drift notes (on:update T05 exception not in ticket Outcome) and DailyGauge selectedDate ordering note.",
+      "schemaVersion": 1,
+      "primaryAgent": "claude",
+      "runnerSelfReport": null,
+      "fallbackFrom": null
     }
   ]
 }

--- a/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.ledger.json
+++ b/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.ledger.json
@@ -1,0 +1,22 @@
+{
+  "ticket": "P6.04",
+  "invocations": [
+    {
+      "runnerKind": "claude-cli",
+      "reviewedHeadSha": "dc35ac26f0932894469f3a05393460306f14e34e",
+      "outcome": "clean",
+      "completedAt": "2026-06-17T03:37:59.277Z",
+      "terminatedReason": "completed",
+      "rawOutput": "docs/product/delivery/phase-06/reviews/P6.04-subagent-review.report.md",
+      "filledPrompt": "docs/product/delivery/phase-06/reviews/P6.04-subagent-review.prompt.md",
+      "fallbackLevel": "preferred",
+      "schemaVersion": 1,
+      "primaryAgent": "claude",
+      "runnerSelfReport": "completed",
+      "fallbackFrom": null,
+      "findings": [],
+      "probedSurfaces": [],
+      "patches": []
+    }
+  ]
+}

--- a/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.prompt.md
+++ b/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.prompt.md
@@ -1,0 +1,135 @@
+You are conducting an adversarial review of a code change.
+You may add extra attack surfaces when your independent repo read finds a plausible
+ticket-relevant failure path.
+Findings outside the three finding-discipline clauses belong in **Advisory Observations** —
+anything off-scope but real is welcome there.
+Your job is not a general code review — it is a targeted attack on the behavior this ticket is supposed to
+protect. Start from the invariants and attack surfaces below, then independently inspect
+the diff and directly related implementation code for missing ticket-relevant risks. You
+are looking for paths where the ticket's intended behavior breaks, not for general
+improvements.
+
+### Ticket scope
+
+**Outcome:**
+- These 8 files use runes only: `LineChart/LineChart.svelte`, `PieChart/PieChart.svelte`, `ScatterPlot/ScatterPlot.svelte`, `Treemap/Treemap.svelte`, `TimelineChart/TimelineChart.svelte`, `GaugeChart/DailyGauge.svelte`, `AiTokenBarChart/AiTokenBarChart.svelte`, `AiLinesPieChart/AiLinesPieChart.svelte`.
+- All apply the T01 ECharts recipe (`$derived option` + `$effect(setOption)`).
+- Each file carries `<svelte:options runes={true}>`.
+- `grep` for legacy idioms in these files returns zero (modulo T05-deferred `on:update` cross-boundary bridges in TimelineChart and DailyGauge).
+
+**Rationale:**
+- Red first: n/a (`Red: skip`).
+- Why this path: mechanical application of the proven T01 recipe across the remaining standalone charts.
+- Alternative considered: per-chart tickets — rejected as ceremony for a solo operator on mechanical work.
+- Deferred: chart control components (T05). `on:update` in TimelineChart and DailyGauge are T05-deferred cross-boundary bridges (same as ActivityChart in T03 — TypeScript rejects `onupdate` as unknown prop until T05 migrates the Svelte 4 child components).
+
+### Files touched
+
+Implementation:
+src/lib/components/LineChart/LineChart.svelte
+src/lib/components/PieChart/PieChart.svelte
+src/lib/components/ScatterPlot/ScatterPlot.svelte
+src/lib/components/Treemap/Treemap.svelte
+src/lib/components/TimelineChart/TimelineChart.svelte
+src/lib/components/GaugeChart/DailyGauge.svelte
+src/lib/components/AiTokenBarChart/AiTokenBarChart.svelte
+src/lib/components/AiLinesPieChart/AiLinesPieChart.svelte
+
+Tests:
+None (Red: skip — behavior-preserving refactor; existing spec guards unchanged).
+
+### Invariants to hold
+
+1. Every file in scope has `<svelte:options runes={true}>` and zero remaining legacy idioms (`export let`, `$:`, `afterUpdate`), with the explicitly documented exception of `on:update` in TimelineChart and DailyGauge deferred to T05.
+2. The T01 ECharts recipe is applied in each chart: `option` is `$derived`, `chart.setOption(option)` is called inside a `$effect`, and the `$effect` guards against an uninitialized chart ref.
+3. `DailyGauge`'s local `selectedDate` state is properly managed: initialized to `$state('')`, updated by the side-effecting `$effect` when `defaultDate` changes, and updated by `onUpdate` when the user selects a date.
+
+### Attack surfaces to probe
+
+1. `DailyGauge.svelte` — `$effect` for `selectedDate` update: `$effect(() => { if (defaultDate && (!selectedDate || !availableDates.includes(selectedDate))) { selectedDate = defaultDate } })`. Probe whether this `$effect` creates an infinite loop: `selectedDate` is `$state`, reading `selectedDate` inside the `$effect` marks it as a dependency, writing `selectedDate = defaultDate` triggers a re-run. Since `availableDates.includes(selectedDate)` then returns true, the condition is false on the second run and no write occurs — but verify this reasoning holds.
+2. `DailyGauge.svelte` — dual `$effect` for chart init: a `$effect` sets `selectedDate` (writing state), and a separate `$effect` re-renders the chart (reading `option` which reads `data` which reads `selectedDate`). Probe whether the ordering guarantee between these two effects is correct: does the chart re-render fire after `selectedDate` is settled, or can it fire with the stale empty string?
+3. `TimelineChart.svelte` — `durations` local state: `let durations = $state(durationsProp)` captures the initial prop. Same pattern as ActivityChart in T03. Probe whether `hasData` and `option` are derived from the local `durations` (not `durationsProp`), and that the `onUpdate` handler writes to `durations` (not `durationsProp`).
+4. `Treemap.svelte` — `$page` store in runes mode: `$page` is used inside two `$derived` expressions. In Svelte 5 runes mode, the `$store` auto-subscribe syntax is still valid. Probe whether TypeScript and the Svelte compiler accept `$page.params.projectName` inside `$derived(...)` in a runes-mode file, and whether the derived values re-run when the page params change.
+5. `AiLinesPieChart.svelte` — nullable option propagation: `option` is `$derived(hasData ? buildAiLinesPieOption(slices!) : null)`. The `$effect` guards with `if (option) chart.setOption(option)`. Probe whether the non-null assertion `slices!` is safe at the point it's evaluated (i.e., `hasData` is true, meaning `slices !== null`).
+
+#### Diff-derived attack surfaces
+
+1. **Output stability across schema-version drift** — [N/A — purely in-memory component refactor; no persisted artifacts or schemas changed].
+2. **CLI flag/arg symmetry** — [N/A — no CLI flags modified].
+3. **Error-class breadth in `catch` blocks** — [N/A — no try/catch blocks in these files; same as T03].
+4. **Defensive layering at module boundaries** — Probe whether `createTimelineChartOption`, `createDisciplineGaugeData`, and `createDisciplineGaugeOption` handle their inputs defensively. `DailyGauge` passes `selectedDate` (which starts as empty string `''`) to `createDisciplineGaugeData`; verify the helper handles an empty string date without throwing before the `$effect` sets it to `defaultDate`.
+5. **Cross-file atomicity windows** — [N/A — no multi-step file writes].
+6. **Test-contract strength** — Probe whether `PieChart.spec.ts`, `AiTokenBarChart.spec.ts`, and `AiLinesPieChart.spec.ts` are compatible with the runes migration — specifically, whether they pass props in a way that works with `$props()`.
+7. **Doc-vs-code drift in the ticket Rationale** — Read the ticket Rationale and outcome against the diff. Verify: (a) T01 recipe applied to all 8 charts; (b) `on:update` bridges in TimelineChart and DailyGauge are correctly identified as T05-deferred; (c) the `DailyGauge` reactive state pattern is correctly described.
+
+### Diff context
+
+Eight files migrated from Svelte 4 to Svelte 5 runes. Patterns:
+
+- **Simple charts (LineChart, PieChart, ScatterPlot, Treemap, AiTokenBarChart, AiLinesPieChart):** `export let` → `$props()`, `$:` → `$derived`, `afterUpdate` → `$effect`. Template unchanged.
+- **TimelineChart:** Same as ActivityChart in T03 — `durations` prop renamed to `durationsProp`, local `let durations = $state(durationsProp)` created, `on:update={onUpdate}` kept as T05 bridge.
+- **DailyGauge:** Most complex. `selectedDate` stays as `$state('')`. `availableDates` and `defaultDate` become `$derived`. The reactive side-effect `$: if (defaultDate && ...) { selectedDate = defaultDate }` becomes `$effect(() => { if (defaultDate && ...) { selectedDate = defaultDate } })`. `on:update={onUpdate}` kept as T05 bridge.
+- `Treemap` uses `$page` from `$app/stores` inside `$derived()` — valid in runes mode.
+
+---
+
+### Your directives
+
+**Scope:** You conduct an adversarial review of the implementation diff and directly
+related code paths named in the attack surfaces. Do not expand scope beyond what the
+ticket outcome describes.
+
+**Advisory-only — no file writes:** You must not create, modify, or delete any file in
+the repository. Your entire deliverable is findings prose in the required output format
+below. The primary execution agent owns all patches.
+
+**Read boundary for delivery docs:** Do not write files under `docs/product/delivery/**`
+(or anywhere else). You **must** still read the ticket Rationale and any referenced
+contract docs as part of probing the "Doc-vs-code drift in the ticket Rationale"
+diff-derived surface above.
+
+**Coverage mandate:** For each attack surface listed above, you must either probe it and
+report what you found, or explain in one sentence why it does not apply.
+
+**Finding discipline:** Report a finding when one of the following holds:
+
+1. The code breaks a stated invariant.
+2. The code introduces a correctness gap you can demonstrate.
+3. **Spec-permits-real-bug:** the ticket's stated contract literally permits the
+   behavior, but that behavior is nevertheless unsafe in production.
+
+Do not report style, preference, or hypothetical future requirements as blocking findings.
+
+**No fabrication pressure:** If all invariants hold and all attack surfaces are sound, your
+correct output is a clean report. Do not invent findings to justify the review step.
+
+---
+
+### Required output format
+
+After completing your review, report in this exact structure (prose only — no file edits).
+
+- Use exactly these five top-level section headings, in this order:
+  `Invariant results`, `Surface results`, `Actionable findings`,
+  `Advisory Observations`, `Runner termination`.
+- **Do not use `---` horizontal rules anywhere in the report.**
+- **`Runner termination` must be the section heading**, not an inline key-value variant.
+- Inside `Advisory Observations`, write **one observation per bullet or one observation per paragraph**. Do NOT use a bold span on a line by itself before the observation body.
+
+**Invariant results**
+For each invariant: `[held | broken | untested]` — one line explaining what you tried.
+
+**Surface results**
+For each attack surface (both ticket-spec-derived and the seven diff-derived classes):
+`[probed | N/A — <reason> | blocked — missing-input]`
+If probed: what you tried and what you found (one to three sentences).
+
+**Actionable findings**
+If none: "None."
+
+**Advisory Observations**
+If none: "None."
+
+**Runner termination**
+runnerStatus: completed | rate_limit | sandbox_denied | runner_unavailable
+terminatedReason: one short sentence explaining why this status was reported.

--- a/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.report.md
+++ b/docs/product/delivery/phase-06/reviews/P6.04-subagent-review.report.md
@@ -1,0 +1,62 @@
+I have enough data. Compiling the report now.
+
+---
+
+**Invariant results**
+
+1. `<svelte:options runes={true}>` present and zero legacy `export let` / `$:` / `afterUpdate` idioms — **held**. All 8 files confirmed on read. `on:update` is present in TimelineChart (line 57) and DailyGauge (line 65); these are the documented T05-deferred cross-boundary bridges and are not in the legacy-idiom ban list.
+
+2. T01 ECharts recipe (`$derived option` + `$effect(setOption)` + guard against uninitialized chart ref) — **held**. LineChart and ScatterPlot guard via `chart?.setOption(option)` (optional-chain null-guard); the remaining six files guard with explicit `if (!chartRef)` checks or `if (!chart)` re-init branches. All 8 have `option` as `$derived`.
+
+3. `DailyGauge` `selectedDate` state lifecycle — **held**. `selectedDate = $state('')`; updated by `$effect` when `defaultDate` changes; updated by `onUpdate` when user selects a date.
+
+---
+
+**Surface results**
+
+**Surface 1 — DailyGauge `$effect` infinite loop probe:** probed. The `$effect` reads `defaultDate`, `selectedDate`, and `availableDates`. First run: `selectedDate = ''` → condition is true → writes `selectedDate = defaultDate`. Second run: `availableDates.includes(selectedDate)` returns true → condition is false → no write. Loop terminates after one write. No infinite loop.
+
+**Surface 2 — DailyGauge dual-effect ordering:** probed. Svelte 5 runs effects in registration order during the mount flush. Declaration order in the file: selectedDate `$effect` (line 29) → `onMount` (line 38) → chart update `$effect` (line 51). So the selectedDate effect fires first (settling `selectedDate = defaultDate`), `onMount` fires second (reading `option` derived from the now-settled `selectedDate`), then the chart update `$effect` fires third. On the initial mount this means `setOption` is called twice — once in `onMount` and once in the chart update `$effect`. ECharts handles repeated `setOption` calls idempotently; no visual artifact. This is the same accepted dual-call pattern as ActivityChart in T03.
+
+**Surface 3 — TimelineChart `durations` local state:** probed. `hasData` (line 27) and `option` (line 28) are both derived from local `durations` (`$state`), not `durationsProp`. `onUpdate` (line 49) writes to `durations`. The pattern is consistent with T03's ActivityChart. ✓
+
+**Surface 4 — Treemap `$page` store in runes mode:** probed. `$page` is a Svelte store; the `$store` auto-subscribe shorthand is valid inside `$derived` in runes mode. The Svelte 5 compiler wraps the store read in the reactive context, so the derived values re-run when page params change. TypeScript accepts this. One pre-existing concern: `$page.params.projectName` is `string | undefined` at runtime (SvelteKit types `params` as `Record<string, string>` but returns `undefined` for missing keys), and `createProjectFileToTimeDict` and `createTreemapOption` declare `projectName: string`. The split `entity.name.split('undefined/')` would silently produce wrong keys if `projectName` is undefined. This gap pre-dates the migration; the runes refactor does not introduce or worsen it.
+
+**Surface 5 — `AiLinesPieChart` `slices!` non-null assertion:** probed. `hasData = $derived(slices !== null)`. In the `option` derivation, `hasData ? buildAiLinesPieOption(slices!) : null` — when `hasData` is true, `slices !== null` is established by the same synchronous computation that evaluates `option`. No concurrency or async gap between `hasData` and `slices` evaluation. The non-null assertion is safe. ✓
+
+**Diff-derived surface 1 — Output stability across schema-version drift:** N/A — purely in-memory component refactor; no persisted artifacts or schemas changed.
+
+**Diff-derived surface 2 — CLI flag/arg symmetry:** N/A — no CLI flags modified.
+
+**Diff-derived surface 3 — Error-class breadth in `catch` blocks:** N/A — no try/catch blocks in these files.
+
+**Diff-derived surface 4 — Defensive layering at module boundaries (`createDisciplineGaugeData` with empty string):** probed. `createDisciplineGaugeData(summaries, '')` evaluates `dateToRatioMap['']` which is `undefined` (no entry for the empty string key). This produces `[{ value: undefined, name: '...' }]`. ECharts accepts this without throwing — the gauge pointer renders at the zero position. Correctness hinges on the ordering proof from Surface 2: by the time `option` is first read (inside `onMount` and the chart update `$effect`), the selectedDate `$effect` has already fired and `selectedDate = defaultDate`. Given Svelte 5's declaration-order scheduling guarantee, `option` is never read with `selectedDate = ''` after mount. This is sound under the current file layout but carries an implicit ordering dependency (see Advisory Observations).
+
+**Diff-derived surface 5 — Cross-file atomicity windows:** N/A — no multi-step file writes.
+
+**Diff-derived surface 6 — Test-contract strength with `$props()`:** probed. All three spec files (`PieChart.spec.ts`, `AiTokenBarChart.spec.ts`, `AiLinesPieChart.spec.ts`) call `render(Component, propsObject)` using `@testing-library/svelte`. In Svelte 5, `render` passes the second argument directly to `mount()` as props, which maps correctly to `$props()` inside the component. The prop shapes are unchanged by this migration. No contract breakage.
+
+**Diff-derived surface 7 — Doc-vs-code drift in ticket Rationale:** probed. The ticket Outcome section (line 13, ticket doc) states "`grep` for legacy idioms in these files returns zero" without qualification. The `on:update` bridge directives are present in two files and are intentional T05-deferred exceptions, but the ticket doc does not record this exception in the Outcome statement. The Rationale section says only "Deferred: chart control components (T05)" without specifying that `on:update` is the deferred idiom or which files carry it. The adversarial review spec contains this qualification; the ticket doc does not. The outcome statement as written is literally false for `on:update` — a future developer grep would find these and have no ticket-level explanation.
+
+---
+
+**Actionable findings**
+
+None.
+
+---
+
+**Advisory Observations**
+
+The ticket outcome statement ("`grep` for legacy idioms in these files returns zero") is literally falsified by the `on:update` directives in TimelineChart and DailyGauge. The T05 deferral is a real and intentional decision, but it lives only in the adversarial review prompt and the `on:update` rationale doc — not in the ticket's Outcome section. A developer running the grep audit against the ticket outcome months from now would find two hits with no ticket-level explanation. Worth appending a one-liner to the Outcome noting the exception: e.g., "exception: `on:update` bridges in TimelineChart and DailyGauge are T05-deferred."
+
+`DailyGauge` correctness during initial mount depends on the Svelte 5 guarantee that `$effect` callbacks fire in declaration order during the mount flush (so the selectedDate effect settles `selectedDate = defaultDate` before `onMount` reads `option`). This guarantee holds under the current file layout. If a future refactor moves the `onMount` block above the selectedDate `$effect`, the gauge would initialize ECharts with `data[0].value = undefined` for one frame before correcting. The dependency on declaration order is not documented. A comment or a restructuring that initializes `selectedDate` synchronously (e.g., `let selectedDate = $state(availableDates.at(-1) ?? '')`) would eliminate the ordering dependency entirely — though that would require the `availableDates` derivation to be declared above `selectedDate`, which may conflict with how `$props()` and `$derived` interact on the initial computation. This is lower priority than the ticket-doc gap above; noting it for T05 or a future audit.
+
+`Treemap` passes `$page.params.projectName` (type: `string | undefined`) into `createProjectFileToTimeDict` and `createTreemapOption` which declare `projectName: string`. If the component ever renders outside a route that provides `projectName` (e.g., a test or a route refactor), the helpers will silently split on the string `"undefined"` and produce garbage tree keys rather than throwing. This is a pre-existing gap untouched by this migration; flagging for visibility since the runes migration is an opportunity to audit it.
+
+---
+
+**Runner termination**
+
+runnerStatus: completed
+terminatedReason: All invariants held, all attack surfaces probed, no actionable findings — report complete.

--- a/docs/product/delivery/phase-06/ticket-04-standalone-charts.md
+++ b/docs/product/delivery/phase-06/ticket-04-standalone-charts.md
@@ -10,7 +10,7 @@ Red: skip
 - These 8 files use runes only: `LineChart/LineChart.svelte`, `PieChart/PieChart.svelte`, `ScatterPlot/ScatterPlot.svelte`, `Treemap/Treemap.svelte`, `TimelineChart/TimelineChart.svelte`, `GaugeChart/DailyGauge.svelte`, `AiTokenBarChart/AiTokenBarChart.svelte`, `AiLinesPieChart/AiLinesPieChart.svelte`.
 - All apply the T01 ECharts recipe (`$derived option` + `$effect(setOption)`).
 - Each file carries `<svelte:options runes={true}>`.
-- `grep` for legacy idioms in these files returns zero.
+- `grep` for legacy idioms in these files returns zero; exception: `on:update` bridges in `TimelineChart.svelte` and `DailyGauge.svelte` are T05-deferred (TypeScript rejects `onupdate` as unknown prop until child controls are migrated to runes).
 
 ## Red
 

--- a/src/lib/components/AiLinesPieChart/AiLinesPieChart.svelte
+++ b/src/lib/components/AiLinesPieChart/AiLinesPieChart.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import * as echarts from 'echarts'
   import type { SummariesResult } from '$src/types/wakatime'
   import Container from '../Container.svelte'
@@ -8,15 +10,15 @@
   import EmptyState from '../EmptyState.svelte'
   import { buildAiLinesPieOption, computeAiLinesSlices } from './AiLinesPieChartHelpers'
 
-  export let summaries: SummariesResult
-  export let title = 'AI vs Human Lines'
+  let { summaries, title = 'AI vs Human Lines' }: { summaries: SummariesResult; title?: string } =
+    $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: slices = computeAiLinesSlices(summaries)
-  $: hasData = slices !== null
-  $: option = hasData ? buildAiLinesPieOption(slices!) : null
+  const slices = $derived(computeAiLinesSlices(summaries))
+  const hasData = $derived(slices !== null)
+  const option = $derived(hasData ? buildAiLinesPieOption(slices!) : null)
 
   onMount(() => {
     if (!chartRef) return
@@ -31,7 +33,7 @@
     }
   })
 
-  afterUpdate(() => {
+  $effect(() => {
     if (!chartRef) return
     if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     if (option) chart.setOption(option)

--- a/src/lib/components/AiTokenBarChart/AiTokenBarChart.svelte
+++ b/src/lib/components/AiTokenBarChart/AiTokenBarChart.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import * as echarts from 'echarts'
   import type { SummariesResult } from '$src/types/wakatime'
   import Container from '../Container.svelte'
@@ -8,15 +10,15 @@
   import EmptyState from '../EmptyState.svelte'
   import { buildAiTokenBarOption, buildAiTokenBarSeries } from './AiTokenBarChartHelpers'
 
-  export let summaries: SummariesResult
-  export let title = 'AI Token Usage'
+  let { summaries, title = 'AI Token Usage' }: { summaries: SummariesResult; title?: string } =
+    $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: series = buildAiTokenBarSeries(summaries)
-  $: hasData = series.hasData
-  $: option = buildAiTokenBarOption(series)
+  const series = $derived(buildAiTokenBarSeries(summaries))
+  const hasData = $derived(series.hasData)
+  const option = $derived(buildAiTokenBarOption(series))
 
   onMount(() => {
     if (!chartRef) return
@@ -31,7 +33,7 @@
     }
   })
 
-  afterUpdate(() => {
+  $effect(() => {
     if (!chartRef) return
     if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     if (hasData) chart.setOption(option)

--- a/src/lib/components/GaugeChart/DailyGauge.svelte
+++ b/src/lib/components/GaugeChart/DailyGauge.svelte
@@ -1,10 +1,11 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { onMount } from 'svelte'
   import * as echarts from 'echarts'
   import dayjs from 'dayjs'
   import advanceFormat from 'dayjs/plugin/advancedFormat.js'
   import type { SummariesResult } from '$src/types/wakatime'
-  import { afterUpdate } from 'svelte'
   import Container from '../Container.svelte'
   import ChartTitle from '../ChartTitle.svelte'
   import { createDisciplineGaugeData, createDisciplineGaugeOption } from './gaugeChartHelpers'
@@ -14,24 +15,25 @@
 
   dayjs.extend(advanceFormat)
 
-  export let summaries: SummariesResult
-  export let title: string
+  let { summaries, title }: { summaries: SummariesResult; title: string } = $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: hasData = (summaries.data?.length ?? 0) > 0
+  const hasData = $derived((summaries.data?.length ?? 0) > 0)
 
-  let selectedDate = ''
-  $: availableDates = summaries.data?.map((summary) => summary.range.date) ?? []
-  $: defaultDate = availableDates.at(-1) ?? ''
+  let selectedDate = $state('')
+  const availableDates = $derived(summaries.data?.map((summary) => summary.range.date) ?? [])
+  const defaultDate = $derived(availableDates.at(-1) ?? '')
 
-  $: if (defaultDate && (!selectedDate || !availableDates.includes(selectedDate))) {
-    selectedDate = defaultDate
-  }
+  $effect(() => {
+    if (defaultDate && (!selectedDate || !availableDates.includes(selectedDate))) {
+      selectedDate = defaultDate
+    }
+  })
 
-  $: data = createDisciplineGaugeData(summaries, selectedDate)
-  $: option = createDisciplineGaugeOption(data)
+  const data = $derived(createDisciplineGaugeData(summaries, selectedDate))
+  const option = $derived(createDisciplineGaugeOption(data))
 
   onMount(() => {
     if (!chartRef) return
@@ -46,7 +48,7 @@
     }
   })
 
-  afterUpdate(() => {
+  $effect(() => {
     if (!chartRef) return
     if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'canvas' })
     chart.setOption(option)

--- a/src/lib/components/LineChart/LineChart.svelte
+++ b/src/lib/components/LineChart/LineChart.svelte
@@ -1,20 +1,21 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import * as echarts from 'echarts'
-  import { onMount, afterUpdate } from 'svelte'
+  import { onMount } from 'svelte'
   import Container from '../Container.svelte'
   import ChartTitle from '../ChartTitle.svelte'
   import { createLineChartData, createLineChartOption } from './lineChartHelpers'
   import type { SummariesResult } from '$src/types/wakatime'
   import ChartContainer from '../common/ChartContainer.svelte'
 
-  export let summaries: SummariesResult
-  export let title: string
+  let { summaries, title }: { summaries: SummariesResult; title: string } = $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: data = createLineChartData(summaries)
-  $: option = createLineChartOption(data, summaries.color)
+  const data = $derived(createLineChartData(summaries))
+  const option = $derived(createLineChartOption(data, summaries.color))
 
   onMount(() => {
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
@@ -28,8 +29,8 @@
     }
   })
 
-  afterUpdate(() => {
-    chart.setOption(option)
+  $effect(() => {
+    chart?.setOption(option)
   })
 </script>
 

--- a/src/lib/components/PieChart/PieChart.svelte
+++ b/src/lib/components/PieChart/PieChart.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import * as echarts from 'echarts'
   import Container from '../Container.svelte'
   import ChartTitle from '../ChartTitle.svelte'
@@ -8,15 +10,14 @@
   import ChartContainer from '../common/ChartContainer.svelte'
   import EmptyState from '../EmptyState.svelte'
 
-  export let summaries: SummariesResult
-  export let title: string
+  let { summaries, title }: { summaries: SummariesResult; title: string } = $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: hasData = (summaries.data?.length ?? 0) > 0
-  $: data = createPieChartData(summaries)
-  $: option = createPieChartOption(data)
+  const hasData = $derived((summaries.data?.length ?? 0) > 0)
+  const data = $derived(createPieChartData(summaries))
+  const option = $derived(createPieChartOption(data))
 
   onMount(() => {
     if (!chartRef) return
@@ -31,7 +32,7 @@
     }
   })
 
-  afterUpdate(() => {
+  $effect(() => {
     if (!chartRef) return
     if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     chart.setOption(option)

--- a/src/lib/components/ScatterPlot/ScatterPlot.svelte
+++ b/src/lib/components/ScatterPlot/ScatterPlot.svelte
@@ -1,9 +1,11 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import type { StorySearchResults } from '$lib/generated/openapi/shortcut'
   import { getStoryBranches } from '$lib/helpers/chartHelpers'
   import type { SummariesResult } from '$src/types/wakatime'
   import * as echarts from 'echarts'
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import Container from '../Container.svelte'
   import ChartTitle from '../ChartTitle.svelte'
   import {
@@ -14,31 +16,39 @@
   } from './scatterPlotHelpers'
   import BigChartContainer from '../common/BigChartContainer.svelte'
 
-  export let summaries: SummariesResult
-  export let stories: StorySearchResults
-  export let title = 'Estimation Accuracy'
+  let {
+    summaries,
+    stories,
+    title = 'Estimation Accuracy',
+  }: { summaries: SummariesResult; stories: StorySearchResults; title?: string } = $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: available_branches = summaries.data
-    ? [
-        ...new Set(
-          summaries.data.flatMap((summary) => summary.branches.map((branch) => branch.name)),
-        ),
-      ]
-    : []
+  const available_branches = $derived(
+    summaries.data
+      ? [
+          ...new Set(
+            summaries.data.flatMap((summary) => summary.branches.map((branch) => branch.name)),
+          ),
+        ]
+      : [],
+  )
 
-  $: storyBranches = getStoryBranches(available_branches)
-  $: branchToEstimateDict = createBranchToEstimateDict(stories)
-  $: branchToTimeDict = createBranchToTimeDict(summaries, available_branches)
-  $: branchesByEstimateDict = createBranchesByEstimateDict(branchToEstimateDict, branchToTimeDict)
+  const storyBranches = $derived(getStoryBranches(available_branches))
+  const branchToEstimateDict = $derived(createBranchToEstimateDict(stories))
+  const branchToTimeDict = $derived(createBranchToTimeDict(summaries, available_branches))
+  const branchesByEstimateDict = $derived(
+    createBranchesByEstimateDict(branchToEstimateDict, branchToTimeDict),
+  )
 
-  $: option = createScatterPlotOption(
-    storyBranches,
-    branchToEstimateDict,
-    branchToTimeDict,
-    branchesByEstimateDict,
+  const option = $derived(
+    createScatterPlotOption(
+      storyBranches,
+      branchToEstimateDict,
+      branchToTimeDict,
+      branchesByEstimateDict,
+    ),
   )
 
   onMount(() => {
@@ -53,8 +63,8 @@
     }
   })
 
-  afterUpdate(() => {
-    chart.setOption(option)
+  $effect(() => {
+    chart?.setOption(option)
   })
 </script>
 

--- a/src/lib/components/TimelineChart/TimelineChart.svelte
+++ b/src/lib/components/TimelineChart/TimelineChart.svelte
@@ -1,8 +1,9 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import type { SupabaseDuration } from '$src/routes/api/supabase/durations/+server'
-  import type { DurationsResult, WakaDuration } from '$src/types/wakatime'
   import * as echarts from 'echarts'
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import DailyChartControls from '../BarChart/DailyChartControls.svelte'
   import DailyTitleContent from '../BarChart/DailyTitleContent.svelte'
   import ChartTitle from '../ChartTitle.svelte'
@@ -12,15 +13,19 @@
   import type { ValueOfDurationItemType } from '$lib/helpers/chartHelpers'
   import EmptyState from '../EmptyState.svelte'
 
-  export let durations: SupabaseDuration
-  export let title = 'Context Switch'
-  export let itemType: ValueOfDurationItemType
+  let {
+    durations: durationsProp,
+    title = 'Context Switch',
+    itemType,
+  }: { durations: SupabaseDuration; title?: string; itemType: ValueOfDurationItemType } = $props()
+
+  let durations = $state(durationsProp)
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: hasData = (durations.data?.length ?? 0) > 0
-  $: option = createTimelineChartOption(durations, itemType)
+  const hasData = $derived((durations.data?.length ?? 0) > 0)
+  const option = $derived(createTimelineChartOption(durations, itemType))
 
   onMount(() => {
     if (!chartRef) return
@@ -35,7 +40,7 @@
     }
   })
 
-  afterUpdate(() => {
+  $effect(() => {
     if (!chartRef) return
     if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     chart.setOption(option)

--- a/src/lib/components/Treemap/Treemap.svelte
+++ b/src/lib/components/Treemap/Treemap.svelte
@@ -1,8 +1,10 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { page } from '$app/stores'
   import type { SummariesResult } from '$src/types/wakatime'
   import * as echarts from 'echarts'
-  import { afterUpdate, onMount } from 'svelte'
+  import { onMount } from 'svelte'
   import Container from '../Container.svelte'
   import ChartTitle from '../ChartTitle.svelte'
   import {
@@ -12,16 +14,14 @@
   } from './treemapHelpers'
   import ChartContainer from '../common/ChartContainer.svelte'
 
-  export let summaries: SummariesResult
-  export let title: string
+  let { summaries, title }: { summaries: SummariesResult; title: string } = $props()
 
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
-  $: filesToTimeDict = createProjectFileToTimeDict(summaries, $page.params.projectName)
-  $: data = createTreemapData(filesToTimeDict)
-
-  $: option = createTreemapOption(data, $page.params.projectName)
+  const filesToTimeDict = $derived(createProjectFileToTimeDict(summaries, $page.params.projectName))
+  const data = $derived(createTreemapData(filesToTimeDict))
+  const option = $derived(createTreemapOption(data, $page.params.projectName))
 
   onMount(() => {
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
@@ -35,8 +35,8 @@
     }
   })
 
-  afterUpdate(() => {
-    chart.setOption(option)
+  $effect(() => {
+    chart?.setOption(option)
   })
 </script>
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P6.04 Standalone charts`
- ticket file: [docs/product/delivery/phase-06/ticket-04-standalone-charts.md](https://github.com/cesarnml/coding-stats/blob/main/docs/product/delivery/phase-06/ticket-04-standalone-charts.md)
- stacked base branch: `agents/p6-03-barchart-family-charts`
- post-verify: outcome `clean` completed at 2026-06-17 03:32 UTC
- subagentReview: outcome `clean` completed at 2026-06-17 03:37 UTC
